### PR TITLE
Jobids for everyone

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,2 @@
 ---
-BUNDLE_FROZEN: "true"
-BUNDLE_PATH: "vendor/bundle"
 BUNDLE_DISABLE_SHARED_GEMS: "1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ deploy:
   module_name: application
   handler_name: handle_event
   environment_variables:
-  - SQS_QUEUE_URL=
+  - SQS_QUEUE_URL=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAALIwga8GCSqGSIb3DQEHBqCBoTCBngIBADCBmAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwPf1qGVd1miM4bOtcCARCAa2yrcOI+k2hX8YEgIw6DABzI04ovMdrwbliOBIT6CKHua6Vnhf8xXG9PrVuVOGYKbzVOKiq2kfdgOQ1S+tGed9Nj/+iJfhAVTzS1YdFZojT4ZJrDbxs8vrkjeb2I/p77gXX99zGeCuRGrySn
   skip_cleanup: true
   access_key_id: "$AWS_ACCESS_KEY_ID_PRODUCTION"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_PRODUCTION"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source 'https://rubygems.org'
 gem 'aws-sdk-sqs'
 gem 'aws-sdk-kms'
 gem 'nypl_log_formatter', '~> 0.1.2'
+gem 'nypl_platform_api_client', '~> 1.0'
 
 group :development, :test do
   gem 'rspec'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.0.2)
     aws-partitions (1.144.0)
     aws-sdk-core (3.47.0)
@@ -17,10 +19,15 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    hashdiff (1.0.0)
     http-2 (0.10.1)
     jmespath (1.4.0)
     nypl_log_formatter (0.1.3)
+    nypl_platform_api_client (1.0.0)
+    public_suffix (4.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -34,6 +41,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    safe_yaml (1.0.5)
+    webmock (3.7.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -42,4 +54,9 @@ DEPENDENCIES
   aws-sdk-kms
   aws-sdk-sqs
   nypl_log_formatter (~> 0.1.2)
+  nypl_platform_api_client (~> 1.0)
   rspec
+  webmock
+
+BUNDLED WITH
+   2.0.2

--- a/lib/deferred_request_handler.rb
+++ b/lib/deferred_request_handler.rb
@@ -21,7 +21,12 @@ class DeferredRequestHandler
         raise RequestError.new "Invalid request path; Only paths that begin /api/v0.1/ supported"
       end
 
+      Application.logger.info("Creating deferred request for #{event['httpMethod']} #{event['path']}: #{event['body']}")
+
       request = DeferredRequest.for_event event
+
+      Application.logger.info("Writing deferred request #{request}")
+
       result = sqs_client.write request
       
       respond 200, { success: true, result: result.to_h }
@@ -31,7 +36,7 @@ class DeferredRequestHandler
 
     rescue => e
       Application.logger.error("Error: #{e}")
-      respond 500, message: e.message
+      respond 500, error_class: e.class, message: e.message
     end
   end
 

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -3,3 +3,6 @@ class RequestError < StandardError
     super
   end
 end
+
+class JobServiceError < StandardError
+end

--- a/lib/job_client.rb
+++ b/lib/job_client.rb
@@ -1,0 +1,43 @@
+require 'nypl_platform_api_client'
+
+class JobClient
+  # POSTs to JobService to create a record, returning the generated id
+  def create_job
+    resp = platform_client.post 'jobs', '', headers: { 'Content-Type' => 'text/plain' }
+
+    raise JobServiceError.new('JobService response empty when generating id') unless resp.respond_to? :dig
+
+    id = resp.dig 'data', 'id'
+    Application.logger.debug "Got response generating jobid: #{resp}"
+
+    raise JobServiceError.new('Could not start job') if id.nil?
+
+    id
+  end
+
+  # Get NyplPlatformApiClient instance
+  def platform_client
+    if @platform_client.nil?
+      raise 'Missing config: ENV.NYPL_OAUTH_ID is not set' unless ENV['NYPL_OAUTH_ID']
+      raise 'Missing config: ENV.NYPL_OAUTH_SECRET is not set ' unless ENV['NYPL_OAUTH_SECRET']
+      raise 'Missing config: ENV.NYPL_OAUTH_URL is not set ' unless ENV['NYPL_OAUTH_URL']
+      raise 'Missing config: ENV.PLATFORM_API_BASE_URL is not set ' unless ENV['PLATFORM_API_BASE_URL']
+
+      kms = KmsClient.new
+      @platform_client = NyplPlatformApiClient.new({
+        client_id: kms.decrypt(ENV['NYPL_OAUTH_ID']),
+        client_secret: kms.decrypt(ENV['NYPL_OAUTH_SECRET']),
+        oauth_url: ENV['NYPL_OAUTH_URL'],
+        log_level: 'error'
+      })
+    end
+
+    @platform_client
+  end
+
+  # POSTs to JobService to create a record, returning the generated id
+  def self.generate_job_id
+    instance = self.new
+    instance.create_job
+  end
+end

--- a/lib/kms_client.rb
+++ b/lib/kms_client.rb
@@ -6,6 +6,7 @@ class KmsClient
     @kms = Aws::KMS::Client.new(region: 'us-east-1')
   end 
 
+  # Decrypt given encrypted string
   def decrypt(cipher)
     # Assume value is base64 encoded:
     decoded = Base64.decode64 cipher

--- a/lib/sqs_client.rb
+++ b/lib/sqs_client.rb
@@ -23,6 +23,10 @@ class SqsClient
     )   
   end
 
+  # Parses given SQS URL, returning a Hash with:
+  #   queue_url: The original URL
+  #   queue_name: The name part of the URL (e.g. "proxy-request-queue-qa"
+  #   endpoint: The protocol & fqdn of the URL
   def parse_sqs_url (queue_url)
     # Strip rogue whitespace from encrypted value:
     queue_url.strip!
@@ -42,6 +46,7 @@ class SqsClient
     ! @sqs_queue_url.match(/\.fifo/).nil?
   end
 
+  # Write `entry` to SQS
   def write (sqs_entry)
     begin
       Application.logger.debug "Writing deferred request id #{sqs_entry.id} to SQS: #{sqs_entry}"

--- a/sam.local-with-api-gateway.yml
+++ b/sam.local-with-api-gateway.yml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: 'proxy-request-service'
 
 Resources:
-  SyncItemMetadataToScsbService:
+  ProxyRequestService:
     Type: AWS::Serverless::Function
     Properties:
       Handler: application.handle_event

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: 'proxy-request-service'
 
 Resources:
-  SyncItemMetadataToScsbService:
+  ProxyRequestService:
     Type: AWS::Serverless::Function
     Properties:
       Handler: application.handle_event

--- a/sam.qa.yml
+++ b/sam.qa.yml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: 'proxy-request-service'
 
 Resources:
-  SyncItemMetadataToScsbService:
+  ProxyRequestService:
     Type: AWS::Serverless::Function
     Properties:
       Handler: application.handle_event
@@ -13,3 +13,7 @@ Resources:
         Variables:
           SQS_QUEUE_URL: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAKowgacGCSqGSIb3DQEHBqCBmTCBlgIBADCBkAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAyf5SLN3bvMXtB5EjUCARCAYwQA44aMtSMj/VLHQB4/lPny0WMivTWtwN5tusjrNAJjlCAI/PW9F98y3HrAdH4lJI7KEMfe43Ex1u57Jx5YI/bBFQKlTyGat7mnyFOIRUOVGH7TqtOeXQ1M6FTMlAbWP67/bQ==
           LOG_LEVEL: debug
+          NYPL_OAUTH_URL: https://isso.nypl.org/
+          NYPL_OAUTH_ID: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGowaAYJKoZIhvcNAQcGoFswWQIBADBUBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDJgrQmkr7pQa4WSF1gIBEIAnLgWjuqFllMpCQWGT/eC/7n/pxFN87zaoJF19zCRHH/ulh4BICTZf
+          NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAx8ZuLftGsgDmOxxBICARCAQ3ZSNw6hWlqI73kLJcs8Zg3O13PKiATfXXDUvGFim/KolFmQDCsVp7JFF9Jg01U++KNtcGJiVev7z3OAPNXc3fqGp6k=
+          PLATFORM_API_BASE_URL: https://qa-platform.nypl.org/api/v0.1/

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -8,6 +8,7 @@ describe Application do
 
   before do
     allow(SqsClient).to receive(:new).and_return(mock_sqs_client)
+    allow(JobClient).to receive(:generate_job_id).and_return('1234')
   end
 
   describe '#handle_event' do
@@ -41,7 +42,7 @@ describe Application do
         "httpMethod" => "POST",
         "path" => "/api/v0.1/some-endpoint",
         "body" => "{ \"foo\": \"bar\" }",
-        "queryStringParameters" => "{ \"foo2\": \"bar2\" }",
+        "queryStringParameters" => { "foo2": "bar2" },
         "requestContext": {
           "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef"
         }

--- a/spec/deferred_request_handler_spec.rb
+++ b/spec/deferred_request_handler_spec.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-sqs'
+require 'webmock/rspec'
 
 require_relative 'spec_helper'
 
@@ -11,10 +12,18 @@ describe DeferredRequestHandler do
     allow(sqs_client).to receive(:send_message).and_return({ message_id: 'message-id' })
 
     allow(KmsClient).to receive(:new).and_return(mock_kms_client)
+
+    ENV['PLATFORM_API_BASE_URL'] = 'https://example.com/api/v0.1/'
+    ENV['NYPL_OAUTH_ID'] = Base64.strict_encode64 'fake-client'
+    ENV['NYPL_OAUTH_SECRET'] = Base64.strict_encode64 'fake-secret'
+    ENV['NYPL_OAUTH_URL'] = 'https://isso.example.com/'
+
+    stub_request(:post, "#{ENV['NYPL_OAUTH_URL']}oauth/token").to_return(status: 200, body: '{ "access_token": "fake-access-token" }')
+    stub_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}jobs").to_return(status: 200, body: '{ "data": { "id": "jobby-jobby-id" } }')
   end
 
   describe '#handle' do
-    it 'writes record to sqs' do
+    it 'should write record to sqs with generated job id' do
       ENV['SQS_QUEUE_URL'] = 'encrypted-stuff'
 
       event = {
@@ -28,7 +37,17 @@ describe DeferredRequestHandler do
       # Note we have to do this *before* it is invoked
       expect(sqs_client).to receive(:send_message).with(equivalent_sqs_entry_to({
         queue_url: 'https://example-domain:4576/queue/proxy-request-service',
-        message_body: "{\"httpMethod\":\"POST\",\"path\":\"/api/v0.1/path\",\"body\":null,\"isBase64Encoded\":null,\"headers\":null,\"queryStringParameters\":null,\"requestId\":\"unique-request-id\"}"
+        # Stringify the message_body:
+        message_body: {
+          "httpMethod": "POST",
+          "path": "/api/v0.1/path",
+          # Further stringify the JSON payload:
+          "body": { "jobId": "jobby-jobby-id" }.to_json,
+          "isBase64Encoded": nil,
+          "headers": nil,
+          "queryStringParameters": nil,
+          "requestId": "unique-request-id"
+        }.to_json
       }))
 
       response = DeferredRequestHandler.new.handle(event)
@@ -43,7 +62,52 @@ describe DeferredRequestHandler do
       expect(body['success']).to eq(true)
       expect(body['result']).to be_a(Hash)
       expect(body['result']['message_id']).to be_a(String)
+    end
 
+    it 'should write record to sqs without jobid if proxyServiceCreateJob=false' do
+      ENV['SQS_QUEUE_URL'] = 'encrypted-stuff'
+
+      event = {
+        "path" => "/api/v0.1/path",
+        "httpMethod" => "POST",
+        "queryStringParameters" => {
+          # This is the method for overriding job creation, which defaults true
+          "proxyServiceCreateJob" => 'false'
+        },
+        "requestContext" => { "requestId" => "unique-request-id" }
+      }
+
+      # Before handling anything, establish the kind of message we expect to be
+      # sent to the Aws::SQS::Client#send_message
+      # Note we have to do this *before* it is invoked
+      expect(sqs_client).to receive(:send_message).with(equivalent_sqs_entry_to({
+        queue_url: 'https://example-domain:4576/queue/proxy-request-service',
+        # Stringify the message_body:
+        message_body: {
+          "httpMethod": "POST",
+          "path": "/api/v0.1/path",
+          # Expect no jobId in the body:
+          "body": nil,
+          "isBase64Encoded": nil,
+          "headers": nil,
+          # Expect the :proxyServiceCreateJob param to have been deleted:
+          "queryStringParameters": {},
+          "requestId": "unique-request-id"
+        }.to_json
+      }))
+
+      response = DeferredRequestHandler.new.handle(event)
+
+      expect(response).to be_a(Hash)
+      expect(response[:statusCode]).to eq(200)
+      expect(response[:body]).to be_a(String)
+      expect(response[:headers]).to be_a(Hash)
+      expect(response[:headers][:"Content-Type"]).to eq('application/json')
+
+      body = JSON.parse(response[:body])
+      expect(body['success']).to eq(true)
+      expect(body['result']).to be_a(Hash)
+      expect(body['result']['message_id']).to be_a(String)
     end
   end
 end

--- a/spec/job_client_spec.rb
+++ b/spec/job_client_spec.rb
@@ -1,0 +1,35 @@
+require 'nypl_platform_api_client'
+
+require_relative 'spec_helper'
+
+describe JobClient do
+  let(:mock_kms_client) { instance_double(Aws::KMS::Client) }
+  let(:mock_platform_api_client) { instance_double(NyplPlatformApiClient) }
+
+  before(:each) do
+    allow(Aws::KMS::Client).to receive(:new).and_return(mock_kms_client)
+    allow(mock_kms_client).to receive(:decrypt).and_return({ plaintext: 'decrypted-stuff' })
+
+    allow(NyplPlatformApiClient).to receive(:new).and_return(mock_platform_api_client)
+  end
+
+  it "should extract id from created job" do
+    allow(mock_platform_api_client).to receive(:post).and_return({ 'data' => { 'id' => '1234' } })
+
+    expect(JobClient::generate_job_id).to eq('1234')
+  end
+
+  it "should raise error if JobService fails" do
+    allow(mock_platform_api_client).to receive(:post).and_return(nil)
+    expect { JobClient::generate_job_id }.to raise_error(JobServiceError)
+
+    allow(mock_platform_api_client).to receive(:post).and_return({})
+    expect { JobClient::generate_job_id }.to raise_error(JobServiceError)
+
+    allow(mock_platform_api_client).to receive(:post).and_return({ 'data' => {} })
+    expect { JobClient::generate_job_id }.to raise_error(JobServiceError)
+
+    allow(mock_platform_api_client).to receive(:post).and_return("Plaintext response")
+    expect { JobClient::generate_job_id }.to raise_error(JobServiceError)
+  end
+end

--- a/spec/kms_client_spec.rb
+++ b/spec/kms_client_spec.rb
@@ -1,0 +1,16 @@
+require 'aws-sdk-kms'
+
+require_relative 'spec_helper'
+
+describe KmsClient do
+  let(:mock_kms_client) { instance_double(Aws::KMS::Client) }
+
+  before(:each) do
+    allow(Aws::KMS::Client).to receive(:new).and_return(mock_kms_client)
+    allow(mock_kms_client).to receive(:decrypt).and_return({ plaintext: 'decrypted-stuff' })
+  end
+
+  it "should extract decrypted value from kms response" do
+    expect(KmsClient.new.decrypt('encrypted-stuff')).to eq('decrypted-stuff')
+  end
+end


### PR DESCRIPTION
Adds functionality to generate a job id via the JobService for every
request that comes in by default. (For now, the way to skip job creation
is to specify proxyServiceCreateJob=false on the request query string.)
Includes expanded tests. Incorporates a new [proposed nypl_platform_api_client](https://github.com/NYPL/ruby-nypl-platform-api-client/pull/1/files) gem.