### PR TITLE
Fix failure to return jobId in response

### DIFF
--- a/lib/deferred_request_handler.rb
+++ b/lib/deferred_request_handler.rb
@@ -29,7 +29,7 @@ class DeferredRequestHandler
 
       result = sqs_client.write request
       
-      respond 200, { success: true, result: result.to_h }
+      respond 200, { success: true, jobId: request.job_id, sqsResult: result }
 
     rescue RequestError => e
       respond 400, message: "RequestError: #{e.message}"

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -56,8 +56,9 @@ describe Application do
 
       body = JSON.parse(response[:body])
       expect(body['success']).to eq(true)
-      expect(body['result']).to be_a(Hash)
-      expect(body['result']['message_id']).to be_a(String)
+      expect(body['sqsResult']).to be_a(Hash)
+      expect(body['sqsResult']['message_id']).to be_a(String)
+      expect(body['jobId']).to eq('1234')
     end
   end
 end

--- a/spec/deferred_request_handler_spec.rb
+++ b/spec/deferred_request_handler_spec.rb
@@ -60,8 +60,10 @@ describe DeferredRequestHandler do
 
       body = JSON.parse(response[:body])
       expect(body['success']).to eq(true)
-      expect(body['result']).to be_a(Hash)
-      expect(body['result']['message_id']).to be_a(String)
+      expect(body['sqsResult']).to be_a(Hash)
+      expect(body['sqsResult']['message_id']).to be_a(String)
+      expect(body['jobId']).to be_a(String)
+      expect(body['jobId']).to eq('jobby-jobby-id')
     end
 
     it 'should write record to sqs without jobid if proxyServiceCreateJob=false' do
@@ -106,8 +108,9 @@ describe DeferredRequestHandler do
 
       body = JSON.parse(response[:body])
       expect(body['success']).to eq(true)
-      expect(body['result']).to be_a(Hash)
-      expect(body['result']['message_id']).to be_a(String)
+      expect(body['sqsResult']).to be_a(Hash)
+      expect(body['sqsResult']['message_id']).to be_a(String)
+      expect(body['jobId']).to be_nil
     end
   end
 end


### PR DESCRIPTION
Fixes an oversight in recent jobId work that ensured jobId is generated
and passed through to SQS but neglected to return the jobId in to the
initiating client!