### PR TITLE
Fix response to more closely resemble -sync counterpart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language:
 - ruby
 install:
+- gem install bundler -v 2.0.2
 - bundle install
 cache:
 - bundler

--- a/lib/deferred_request.rb
+++ b/lib/deferred_request.rb
@@ -83,7 +83,7 @@ class DeferredRequest
   def compute_job_id
     job_id = JobClient::generate_job_id
     request_body[:jobId] = job_id
-    response[:jobId] = job_id
+    response[:data][:jobId] = job_id
 
     Application.logger.debug("Added jobid to DeferredRequest: #{@original_request[:body]}")
   end
@@ -92,9 +92,9 @@ class DeferredRequest
   # the request:
   def default_response
     # Establish what request params should be returned to caller:
-    [:itemBarcode].inject({}) do |h, prop|
+    [:itemBarcode].inject({ data: {} }) do |h, prop|
       val = request_body[prop.to_s]
-      h[prop] = val if val
+      h[:data][prop] = val if val
       h
     end
   end

--- a/lib/deferred_request_handler.rb
+++ b/lib/deferred_request_handler.rb
@@ -42,6 +42,6 @@ class DeferredRequestHandler
 
   def respond(statusCode = 200, body = nil)
     Application.logger.debug("Responding with #{statusCode}", body)
-    { statusCode: statusCode, body: body.to_json, headers: { "Content-Type": "application/json" } }
+    { statusCode: statusCode, body: { statusCode: statusCode }.merge(body).to_json, headers: { "Content-Type": "application/json" } }
   end
 end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -58,8 +58,9 @@ describe Application do
       expect(body['success']).to eq(true)
       expect(body['sqsResult']).to be_a(Hash)
       expect(body['sqsResult']['message_id']).to be_a(String)
-      expect(body['jobId']).to eq('1234')
-      expect(body['itemBarcode']).to eq('item-barcode')
+      expect(body['data']).to be_a(Hash)
+      expect(body['data']['jobId']).to eq('1234')
+      expect(body['data']['itemBarcode']).to eq('item-barcode')
     end
   end
 end

--- a/spec/deferred_request_handler_spec.rb
+++ b/spec/deferred_request_handler_spec.rb
@@ -62,8 +62,9 @@ describe DeferredRequestHandler do
       expect(body['success']).to eq(true)
       expect(body['sqsResult']).to be_a(Hash)
       expect(body['sqsResult']['message_id']).to be_a(String)
-      expect(body['jobId']).to be_a(String)
-      expect(body['jobId']).to eq('jobby-jobby-id')
+      expect(body['data']).to be_a(Hash)
+      expect(body['data']['jobId']).to be_a(String)
+      expect(body['data']['jobId']).to eq('jobby-jobby-id')
     end
 
     it 'should write record to sqs without jobid if proxyServiceCreateJob=false' do


### PR DESCRIPTION
Fix issue where the response returned to client does not resemble the
response typically returned to clients by -sync endpoint counterparts.

As it is, proxied endpoints return something like this:

```
{
    "itemBarcode": "33433067789531",
    "jobId": "5835f3e6ff961400",
    "success": true,
    "sqsResult": "{:md5_of_message_body=>\"89facfa6946deaa000840abdd6d1a40b\", :md5_of_message_attributes=>nil, :md5_of_message_system_attributes=>nil, :message_id=>\"0b53abca-cc2a-4219-8a96-8e8a3a4aa0cc\", :sequence_number=>nil}"
}
```

The -sync version of the endpoint should return something like:

```
{
   "data":{
      "id":"1",
      "updatedDate":"",
      "createddate":"",
      "jobId":"5835f3e6ff961400",
      "itemBarcode":"33433067789531"
   },
   "count":"1",
   "statusCode":"200",
   "debugInfo":[]
}
```

This change ensures that a proxied request responds with something like:

```
{
   "data":{
      "jobId":"5835f3e6ff961400",
      "itemBarcode":"33433067789531"
   },
   "statusCode":"200",
   "success": true,
   "sqsResult": "{:md5_of_message_body=>\"89facfa6946deaa000840abdd6d1a40b\", :md5_of_message_attributes=>nil, :md5_of_message_system_attributes=>nil, :message_id=>\"0b53abca-cc2a-4219-8a96-8e8a3a4aa0cc\", :sequence_number=>nil}"
}
```

The ProxyRequestService must resemble the structure of the -sync
counterparts with respect to where the jobId is found, at a minimum.
This change moves the `jobId` and `itemBarcode` properties from the root
level of the response to inside a new `data` property, which is the
convention for the endpoints currently proxied. It also adds `statusCode`. There's more we could do to reduce differences between -sync and proxied endpoints, but this addresses an immediate HTC integration need.