### PR TITLE
Setting the KMS client with aws keys if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All config is in sam.[ENVIRONMENT].yml templates, encrypted as necessary.
 The following will invoke the lambda against the sample `event.json`:
 
 ```sh
-sam local invoke --event event.json --region us-east-1 --template sam.[ENVIRONMENT].yml --profile nypl-digital-dev
+AWS_ACCESS_KEY_ID=[your access key id] AWS_SECRET_ACCESS_KEY=[your secret access key] sam local invoke --event event.json --region us-east-1 --template sam.[ENVIRONMENT].yml 
 ```
 
 Note also that if you choose `sam.local.yml`, you'll need to start SQS via Localstack as a prerequesite to above.
@@ -72,13 +72,13 @@ That will enable you to use the `aws` cli using `--profile local`, which means y
 Add the queue:
 
 ```sh
-aws sqs create-queue --region us-east-1 --queue-name proxy-request-service --endpoint http://localhost:4566 --profile local
+aws sqs create-queue --region us-east-1 --queue-name proxy-request-service --endpoint http://localhost:4566 --profile nypl-digital-dev local
 ```
 
 When populating an SQS queue, the `aws sqs` cli tool may be useful for inspecting the messages written. For example, when populating a localstack SQS, run the following to pop the last 10 messages:
 
 ```sh
-aws sqs receive-message --region us-east-1 --queue-url http://localhost:4566/000000000000/proxy-request-service --endpoint http://localhost:4566 --profile local --attribute-names All --message-attribute-names All --max-number-of-messages 10
+aws sqs receive-message --region us-east-1 --queue-url http://localhost:4566/000000000000/proxy-request-service --endpoint http://localhost:4566 --profile nypl-digital-dev --attribute-names All --message-attribute-names All --max-number-of-messages 10
 ```
 
 #### Modifying `event.json`
@@ -86,7 +86,7 @@ aws sqs receive-message --region us-east-1 --queue-url http://localhost:4566/000
 Update `event.json` as follows:
 
 ```
-sam local generate-event apigateway aws-proxy --path api/v0.1/checkout-request --method POST --body "{ \"itemBarcode\": \"01234567891011\", \"patronBarcode\": \"10119876543210\", \"owningInstitutionId\": \"NYPL\", \"desiredDueDate\": \"2020-03-19T04:00:00Z\" }" > event.json
+AWS_ACCESS_KEY_ID=[your access key id] AWS_SECRET_ACCESS_KEY=[your secret access key] sam local generate-event apigateway aws-proxy --path api/v0.1/checkout-request --method POST --body "{ \"itemBarcode\": \"01234567891011\", \"patronBarcode\": \"10119876543210\", \"owningInstitutionId\": \"NYPL\", \"desiredDueDate\": \"2020-03-19T04:00:00Z\" }" > event.json
 ```
 
 ### Running server locally
@@ -94,7 +94,7 @@ sam local generate-event apigateway aws-proxy --path api/v0.1/checkout-request -
 To run the server locally using a SAM template with a configured API Gateway event:
 
 ```
-sam local start-api --region us-east-1 --template sam.local-with-api-gateway.yml --profile [aws profile]
+AWS_ACCESS_KEY_ID=[your access key id] AWS_SECRET_ACCESS_KEY=[your secret access key] sam local start-api --region us-east-1 --template sam.local-with-api-gateway.yml
 ```
 
 ### Gemfile Changes

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ That will enable you to use the `aws` cli using `--profile local`, which means y
 Add the queue:
 
 ```sh
-aws sqs create-queue --region us-east-1 --queue-name proxy-request-service --endpoint http://localhost:4566 --profile nypl-digital-dev local
+aws sqs create-queue --region us-east-1 --queue-name proxy-request-service --endpoint http://localhost:4566 --profile local
 ```
 
 When populating an SQS queue, the `aws sqs` cli tool may be useful for inspecting the messages written. For example, when populating a localstack SQS, run the following to pop the last 10 messages:
 
 ```sh
-aws sqs receive-message --region us-east-1 --queue-url http://localhost:4566/000000000000/proxy-request-service --endpoint http://localhost:4566 --profile nypl-digital-dev --attribute-names All --message-attribute-names All --max-number-of-messages 10
+aws sqs receive-message --region us-east-1 --queue-url http://localhost:4566/000000000000/proxy-request-service --endpoint http://localhost:4566 --profile local --attribute-names All --message-attribute-names All --max-number-of-messages 10
 ```
 
 #### Modifying `event.json`

--- a/lib/kms_client.rb
+++ b/lib/kms_client.rb
@@ -3,11 +3,15 @@ require 'base64'
 
 class KmsClient
   def initialize
-    @kms = Aws::KMS::Client.new(
-      region: 'us-east-1',
-      access_key_id:  ENV['AWS_ACCESS_KEY_ID'],
-      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
-    )
+    if ENV['AWS_ACCESS_KEY_ID']
+      @kms = Aws::KMS::Client.new(
+        region: 'us-east-1',
+        access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+        secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+      )
+    else
+      @kms = Aws::KMS::Client.new(region: 'us-east-1')
+    end
   end 
 
   # Decrypt given encrypted string

--- a/lib/sqs_client.rb
+++ b/lib/sqs_client.rb
@@ -17,10 +17,19 @@ class SqsClient
 
     @sqs_queue_url = sqs_config[:queue_url]
 
-    @sqs = Aws::SQS::Client.new(
-      region: 'us-east-1',
-      endpoint: sqs_config[:endpoint]
-    )   
+    if ENV['AWS_ACCESS_KEY_ID']
+      @sqs = Aws::SQS::Client.new(
+        region: 'us-east-1',
+        access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+        secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+        endpoint: sqs_config[:endpoint]
+      )   
+    else   
+      @sqs = Aws::SQS::Client.new(
+        region: 'us-east-1',
+        endpoint: sqs_config[:endpoint]
+      )   
+    end
   end
 
   # Parses given SQS URL, returning a Hash with:


### PR DESCRIPTION
This updated is needed because the aws credential env vars are not available in the AWS Lambda. Since it's deployed to the `nypl-digital-dev` account, the values don't need to be passed in explicitly. When running locally, however, they do need to be set explicitly when running with sam.

This PR also updates the README with updated command script when running sam locally. This is based on @danamansana 's update to [sync-item-metadata-to-scsb-service](https://github.com/NYPL/sync-item-metadata-to-scsb-service/pull/1/files)
